### PR TITLE
Update SC voting document to state that nominees that don't reply will not be candidates in the election

### DIFF
--- a/steering-council-elections.md
+++ b/steering-council-elections.md
@@ -28,7 +28,7 @@ This phase should run for approximately one week, with the timeframe announced b
 
 Sitting members of the Steering Council are expected to announce their intent to re-run, or the lack thereof, prior to the nomination phase.
 
-After a nomination has been received, the corresponding election officer should send a message to the nominee, confirming that they accept the nomination. If a nominee does not respond within the set timeframe, it will be assumed that they accepted the nomination.
+After a nomination has been received, the corresponding election officer should send a message to the nominee, confirming that they accept the nomination. If a nominee does not respond within the set timeframe, it will be assumed that they do not accept the nomation.
 
 ### Phase Two: Voting
 


### PR DESCRIPTION
I think it makes the most sense to assume that a lack of reply is a disapproval of the nomination, as to not give a person a higher role without their explicit consent and understanding of the powers they could receive.