### PR TITLE
Propose a limit of two consecutive terms on SC members

### DIFF
--- a/steering-council-elections.md
+++ b/steering-council-elections.md
@@ -60,6 +60,10 @@ If a Steering Council member cannot be reached and there is an important time-se
 
 The newly elected member(s) will now act as the Steering Council member in question until the original Steering Council member(s) returns or their term expires.
 
+## Term Limits
+
+Steering Council members cannot serve for more than two consecutive terms.
+
 ## Considerations
 
 Before the election is started, ensure that the Grace Period role is taken care of. See more [info about that here.](./inactivity-policy#grace-period-at-steering-council-voting)


### PR DESCRIPTION
This PR proposes that SC members are limited to serving two consecutive terms. This idea was coined around multiple times in the past and I thought I'd officially propose it and see where it goes from here.
My reasoning is that term limits would prevent the possibility of effectively adding back permanent seats if one member of the council chooses to run for multiple years and wins each time, especially with our current voting system relative preference cannot be expressed and therefore, if votes are more spread out, a member may be elected to the council with the continued support of the same smaller fraction of the team (that doesn't have to be a majority).
It would also further the "rotation" of the council between members, alongside the already existing provision that requires one member of the council not to run again.

Discuss!